### PR TITLE
Fix schema generation by adding hstore to native_database_types

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -137,6 +137,11 @@ module ActiveRecord
 
       alias :old_quote :quote
       alias :old_columns :columns
+      alias :old_native_database_types :native_database_types
+    
+      def native_database_types
+        old_native_database_types.merge({:hstore => { :name => "hstore" }})
+      end
 
       # Quotes correctly a hstore column value.
       def quote(value, column = nil)


### PR DESCRIPTION
ActiveRecord's dump_schema uses the native_database_types method of the adapter to determine which types are valid.
This patch adds hstore to the native_database_types of the Postgres adapter via a monkeypatch, allowing dump_schema to work and Rails to generate a proper schema.rb with hstore columns and this plugin.

Tested with Rails/ActiveRecord 3.0.3 and all seems well.
