### PR TITLE
Update README with installation instructions for Macs.

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -30,6 +30,8 @@ On Ubuntu, this is easy:
 
 On Mac <del>...you are screwed. Use a VM.</del> you should use "the binary package kindly provided by EnterpriseDB":http://www.enterprisedb.com/products-services-training/pgdownload#osx
 
+"Homebrew's":https://github.com/mxcl/homebrew Postgres installation also includes the contrib packages. @brew install postgres@
+
 h2. Install
 
 Hstore is a postgres contrib type. Check it out first:


### PR DESCRIPTION
Update README: installing Postgres with hombrew on Macs also includes contrib packages.
