### PR TITLE
Escape single quotes for hash keys

### DIFF
--- a/lib/activerecord-postgres-hstore/hash.rb
+++ b/lib/activerecord-postgres-hstore/hash.rb
@@ -5,7 +5,7 @@ class Hash
   def to_hstore
     return "''" if empty?
     #@todo DIOGO! Check security issues with this quoting pleaz
-    map{|idx,val| "('#{idx}'=>'#{val.to_s.gsub(/'/,"''")}')"  }.join(' || ')
+    map{|idx, val| "('#{idx.to_s.escape_quotes}'=>'#{val.to_s.escape_quotes}')"  }.join(' || ')
   end
 
   # If the method from_hstore is called in a Hash, it just returns self.

--- a/lib/activerecord-postgres-hstore/string.rb
+++ b/lib/activerecord-postgres-hstore/string.rb
@@ -28,4 +28,8 @@ class String
     Hash[ scan(/"([^"]+)"=>"([^"]+)"/) ]
   end
 
+  def escape_quotes
+    self.gsub(/'/,"''")
+  end
+
 end

--- a/spec/activerecord-postgres-hstore_spec.rb
+++ b/spec/activerecord-postgres-hstore_spec.rb
@@ -2,28 +2,32 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
 describe "ActiverecordPostgresHstore" do
 
-  it "should convert hstore string to hash" do
+  it "should convert hash to hstore string" do
     ["('a'=>'1') || ('b'=>'2')", "('b'=>'2') || ('a'=>'1')"].should include({:a => 1, :b => 2}.to_hstore)
   end
 
-  it "should convert hash to hstore string" do
-    {:a => 1, :b => 2}.to_hstore.should == "('a'=>'1') || ('b'=>'2')"
-  end
-
   it "should convert hstore string to hash" do
-    '"a"=>"1", "b"=>"2"'.from_hstore.should == {'a' => '1', 'b' => '2'}
+    '"a"=>"1", "b"=>"2"'.from_hstore.should eq({'a' => '1', 'b' => '2'})
   end
  
   it "should quote correctly" do
-    {:a => "'a'"}.to_hstore.should == "('a'=>'''a''')"
+    {:a => "'a'"}.to_hstore.should eq("('a'=>'''a''')")
+  end
+
+  it "should quote keys correctly" do
+    {"'a'" => "a"}.to_hstore.should  eq("('''a'''=>'a')")
+  end
+
+  it "should unquote keys correctly" do
+    "\"'a'\"=>\"a\"".from_hstore.should eq({"'a'" => "a"})
   end
 
   it "should convert empty hash" do
-    {}.to_hstore.should == "''"
+    {}.to_hstore.should eq("''")
   end
 
   it "should convert empty string" do
-    ''.from_hstore.should == {}
+    ''.from_hstore.should eq({})
   end
   
 end


### PR DESCRIPTION
Escape single quotes for hash keys in hash.to_hstore. Updated specs.
