### PR TITLE
Always escape keys and value to handle Unicode values

### DIFF
--- a/lib/activerecord-postgres-hstore/hash.rb
+++ b/lib/activerecord-postgres-hstore/hash.rb
@@ -15,7 +15,7 @@ class Hash
         end
       }
 
-      "\"%s\"=>%s" % iv
+      "%s=>%s" % iv
     } * ","
   end
 


### PR DESCRIPTION
I came across some cases with Unicode values where I'd get an error that it's not a valid UTF-8 byte sequence, so I patched to_hstore to always escape, regardless of whether we think we need to or not.

Another way of fixing this would be to include the cases I came across in the regex that decided whether to escape or not, but I felt that always escaping is safer.
