### PR TITLE
Create or drop hstore extension only if necessary

### DIFF
--- a/lib/templates/setup_hstore91.rb
+++ b/lib/templates/setup_hstore91.rb
@@ -1,9 +1,9 @@
 class SetupHstore < ActiveRecord::Migration
   def self.up
-    execute "CREATE EXTENSION hstore"
+    execute "CREATE EXTENSION IF NOT EXISTS hstore"
   end
 
   def self.down
-    execute "DROP EXTENSION hstore"
+    execute "DROP EXTENSION IF EXISTS hstore"
   end
 end


### PR DESCRIPTION
I ran into a small issue on a production server where the Rails db user doesn't have the necessary permissions to create extensions. A simple workaround without having to alter permissions is: Create the extension manually as superuser and then run the migration. For this to work, however, the statements need to be extended with IF NOT EXISTS and IF EXISTS. Nothing big really since it doesn't change the current behavior.
