### PR TITLE
Correct template path for generator

### DIFF
--- a/lib/activerecord-postgres-hstore/railties.rb
+++ b/lib/activerecord-postgres-hstore/railties.rb
@@ -28,7 +28,7 @@ class Hstore < Rails::Railtie
     include Rails::Generators::Migration
 
     def self.source_root
-      @source_root ||= File.join(File.dirname(__FILE__), 'templates')
+      @source_root ||= File.join(File.dirname(__FILE__), '../templates')
     end
 
     def self.next_migration_number(dirname)


### PR DESCRIPTION
Hello,

The relative path to ./templates seems to have changed from the generator's perspective.
Simple patch to fix.
Is there an obvious way to test this?  Seems like glue to me.
