### PR TITLE
Correctly parse double quoted hstore format on multiple lines

### DIFF
--- a/lib/activerecord-postgres-hstore/string.rb
+++ b/lib/activerecord-postgres-hstore/string.rb
@@ -24,7 +24,7 @@ class String
       [k,v].map { |t| 
         case t
         when nil then t
-        when /^"(.*)"$/ then $1.gsub(/\\(.)/, '\1')
+        when /\A"(.*)"\Z/m then $1.gsub(/\\(.)/, '\1')
         else t.gsub(/\\(.)/, '\1')
         end
       }

--- a/spec/activerecord-postgres-hstore_spec.rb
+++ b/spec/activerecord-postgres-hstore_spec.rb
@@ -78,5 +78,11 @@ describe "ActiverecordPostgresHstore" do
     ''.from_hstore.should eq({})
     '         '.from_hstore.should eq({})
   end
+
+  it "should not change values with line breaks" do
+    input = { "a" => "foo\n\nbar" }
+    output = input.to_hstore
+    output.from_hstore.should eq(input)
+  end
   
 end


### PR DESCRIPTION
This fixes softa/activerecord-postgres-hstore#32.
