### PR TITLE
Check if Rails is defined

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -66,7 +66,7 @@ module ActiveRecord
       destroy_keys(attribute, *keys).save
     end
 
-    if Rails.version < '3.1.0'
+    if defined?(Rails) && Rails.version < '3.1.0'
     # This method is replaced for Rails 3 compatibility.
     # All I do is add the condition when the field is a hash that converts the value
     # to hstore format.


### PR DESCRIPTION
so that this plugin can be used in an ActiveRecord-without-Rails project
