### PR TITLE
In README examples, the > operator should be @>

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Find records where 'foo’ is equal to 'bar’:
 This same sql is at least twice as fast (using indexes) if you do it
 that way:
 
-    Person.where("data > 'foo=>bar'")
+    Person.where("data @> 'foo=>bar'")
 
 Find records where 'foo’ is not equal to 'bar’:
 


### PR DESCRIPTION
When trying `Person.where("data > 'foo=>bar'")`, I got a syntax error. According to the PostgreSQL 9.1 docs, `Person.where("data @> 'foo=>bar'")` is the correct syntax, which upon trying, returned a successful query.
