### PR TITLE
Migration helper functions

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -103,6 +103,19 @@ module ActiveRecord
 
     module SchemaStatements
 
+      # Installs hstore by creating the Postgres extension
+      # if it does not exist
+      #
+      def install_hstore
+        execute "CREATE EXTENSION IF NOT EXISTS hstore"
+      end
+
+      # Uninstalls hstore by dropping Postgres extension if it exists
+      #
+      def uninstall_hstore
+        execute "DROP EXTENSION IF EXISTS hstore"
+      end
+
       # Adds a GiST or GIN index to a table which has an hstore column.
       #
       # Example:


### PR DESCRIPTION
Provides support to migrations by adding the following methods:
- `install_hstore` - creates the hstore extension
- `uninstall_hstore` - drops the hstore extension
- `add_hstore_index` - creates a `:gist` or `:gin` index for an hstore column
- `remove_hstore_index` - drops a `:gist` or `:gin` index on an hstore column

Example schema migration for a products table to add an hstore index:

``` ruby
class AddHstoreIndexToProducts < ActiveRecord::Migration
  def up
    add_hstore_index :products, :hstore_data, :type => :gin
  end

  def down
    remove_hstore_index :products, :hstore_data
  end
end
```
