### PR TITLE
Alias Method Chain

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -72,23 +72,23 @@ module ActiveRecord
     # to hstore format.
     # IMHO this should be delegated to the column, so it won't be necessary to rewrite all
     # this method.
-    def arel_attributes_values(include_primary_key = true, include_readonly_attributes = true, attribute_names = @attributes.keys)
-      attrs = {}
+    def arel_attributes_values_with_hstore(include_primary_key = true, include_readonly_attributes = true, attribute_names = @attributes.keys)
+      hstore_attrs, hstore_keys = {}, []
       attribute_names.each do |name|
-        if (column = column_for_attribute(name)) && (include_primary_key || !column.primary)
+        if column = column_for_attribute(name) # We don't care about primary key because hstore
           if include_readonly_attributes || (!include_readonly_attributes && !self.class.readonly_attributes.include?(name))
-            value = read_attribute(name)
+            value = read_attribute name
             if self.class.columns_hash[name].type == :hstore && value && value.is_a?(Hash)
-              value = value.to_hstore # Done!
-            elsif value && self.class.serialized_attributes.has_key?(name) && (value.acts_like?(:date) || value.acts_like?(:time) || value.is_a?(Hash) || value.is_a?(Array))
-              value = value.to_yaml
+              key = self.class.arel_table[name]
+              hstore_attrs[key] = value
             end
-            attrs[self.class.arel_table[name]] = value
           end
         end
       end
-      attrs
+      arel_attributes_values_without_hstore(include_primary_key, include_readonly_attributes, attribute_names.reject { |key| hstore_keys.include? key })# + hstore_attrs
     end
+
+    alias_method_chain :arel_attributes_values, :hstore
     end
 
   end


### PR DESCRIPTION
Why doesn't [ActiveRecord::Base#arel_attributes_values](https://github.com/engageis/activerecord-postgres-hstore/blob/master/lib/activerecord-postgres-hstore/activerecord.rb#L75-L91) use alias_method_chain? Seems that would be less intrusive so other gems (like [activerecord-postgres-array](https://github.com/tlconnor/activerecord-postgres-array/)) could do their business in that class and method without business like [this](https://github.com/tlconnor/activerecord-postgres-array/blob/master/lib/activerecord-postgres-array/activerecord.rb#L19-L20).

I'ma start hacking on this now but was wondering why it wasn't done already. Anyone have any pointers?
