### PR TITLE
Added subclass statements to PostgreSQLAdapter & PostgreSQLColumn

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -176,7 +176,7 @@ module ActiveRecord
 
     end
 
-    class PostgreSQLColumn
+    class PostgreSQLColumn < Column
       # Does the type casting from hstore columns using String#from_hstore or Hash#from_hstore.
       def type_cast_code_with_hstore(var_name)
         type == :hstore ? "#{var_name}.from_hstore" : type_cast_code_without_hstore(var_name)
@@ -191,7 +191,7 @@ module ActiveRecord
       alias_method_chain :simplified_type, :hstore
     end
 
-    class PostgreSQLAdapter
+    class PostgreSQLAdapter < AbstractAdapter
       def native_database_types_with_hstore
         native_database_types_without_hstore.merge({:hstore => { :name => "hstore" }})
       end


### PR DESCRIPTION
I was getting runtime errors for methods not available to PostgreSQLAdapter & PostgreSQLColumn in a non rails project.  Adding the subclass statements to those two classes fixed the problem.  
