### PR TITLE
Add support for a default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ code should look like:
       serialize :data, ActiveRecord::Coders::Hstore
     end
 
+If you want a default value (say, an empty hash) you should pass it as an argument when you
+initialize the serializer, like so:
+
+    class Person < ActiveRecord::Base
+      serialize :data, ActiveRecord::Coders::Hstore.new({})
+    end
+
+This way, you will automatically start with an empty hash that you can write attributes to.
+
+    irb(main):001:0> person = Person.new
+    => #<Person id: nil, name: nil, data: {}, created_at: nil, updated_at: nil>
+    irb(main):002:0> person.data['favorite_color'] = 'blue'
+    => "blue"
+
+If you skip this step, you will have to manually initialize the value to an empty hash before
+writing to the attribute, or else you will get an error:
+
+    NoMethodError: undefined method `[]=' for nil:NilClass
+
 Install
 -------
 

--- a/lib/activerecord-postgres-hstore/coder.rb
+++ b/lib/activerecord-postgres-hstore/coder.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       end
 
       def load(hstore)
-        hstore.nil? ? nil : hstore.from_hstore
+        hstore.nil? ? @default : hstore.from_hstore
       end
     end
   end

--- a/spec/activerecord-coders-hstore_spec.rb
+++ b/spec/activerecord-coders-hstore_spec.rb
@@ -20,4 +20,8 @@ describe "ActiverecordCodersHstore" do
   it 'should dump the default given nil' do
     ActiveRecord::Coders::Hstore.new({'a'=>'a'}).dump(nil).should == {'a'=>'a'}.to_hstore
   end
+
+  it 'should load the default given nil' do
+    ActiveRecord::Coders::Hstore.new({'a'=>'a'}).load(nil).should eql({'a'=>'a'})
+  end
 end


### PR DESCRIPTION
First, I fixed the spec so that both spec files will run when `rake spec` is executed.

Additionally, I updated the default value so that it is used for new records. Because overwriting the accessors to provide a default value isn't possible with serializers, it is necessary to handle it this way. I have updated the readme to show how these changes would be used (how we are using them here) and have written a spec for the behavior.
