### PR TITLE
JRuby Regression Update

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -66,9 +66,11 @@ module ActiveRecord
     end
   end
 
+
   module ConnectionAdapters
+    #I believe this change will break the ability to do a schema dump as per issue #83
+    #https://github.com/engageis/activerecord-postgres-hstore/commit/ca34391c776949c13d561870067ddf581f0561b9#lib/activerecord-postgres-hstore/activerecord.rb
     if(RUBY_PLATFORM != 'java')
-	
       class PostgreSQLColumn < Column
         # Adds the hstore type for the column.
         def simplified_type_with_hstore(field_type)
@@ -79,6 +81,23 @@ module ActiveRecord
       end
 
       class PostgreSQLAdapter < AbstractAdapter
+        def native_database_types_with_hstore
+          native_database_types_without_hstore.merge({:hstore => { :name => "hstore" }})
+        end
+
+        alias_method_chain :native_database_types, :hstore
+      end
+    else
+      class PostgreSQLColumn
+        # Adds the hstore type for the column.
+        def simplified_type_with_hstore(field_type)
+          field_type == 'hstore' ? :hstore : simplified_type_without_hstore(field_type)
+        end
+
+        alias_method_chain :simplified_type, :hstore
+      end
+
+      class PostgreSQLAdapter
         def native_database_types_with_hstore
           native_database_types_without_hstore.merge({:hstore => { :name => "hstore" }})
         end


### PR DESCRIPTION
Fixes a regression introduced for schema dumping feature in >0.70 via     https://github.com/engageis/activerecord-postgres-hstore/commit/ca34391c776949c13d561870067ddf581f0561b9#lib/activerecord-postgres-hstore/activerecord.rb

I updated the PostgreSQLColumn and PostgreSQLAdapter classes to be compatible with JRuby like it was prior to 0.70.  Please let me know if you have any questions or comments.
