### PR TITLE
Fixed Superclass Mismatch Error w JDBC adapter

### DIFF
--- a/lib/activerecord-postgres-hstore/activerecord.rb
+++ b/lib/activerecord-postgres-hstore/activerecord.rb
@@ -67,7 +67,25 @@ module ActiveRecord
   end
 
   module ConnectionAdapters
-    class PostgreSQLColumn < Column
+
+    def self.Column
+      if const_defined?('JdbcColumn')
+        const_get('JdbcColumn')
+      else
+        const_get('Column')
+      end
+    end
+
+    def self.Adapter
+      if const_defined?('JdbcAdapter')
+        const_get('JdbcAdapter')
+      else
+        const_get('AbstractAdapter')
+      end
+    end
+
+
+    class PostgreSQLColumn < Column()
       # Adds the hstore type for the column.
       def simplified_type_with_hstore(field_type)
         field_type == 'hstore' ? :hstore : simplified_type_without_hstore(field_type)
@@ -76,7 +94,7 @@ module ActiveRecord
       alias_method_chain :simplified_type, :hstore
     end
 
-    class PostgreSQLAdapter < AbstractAdapter
+    class PostgreSQLAdapter < Adapter()
       def native_database_types_with_hstore
         native_database_types_without_hstore.merge({:hstore => { :name => "hstore" }})
       end


### PR DESCRIPTION
When running with jruby (using`activerecord-jdbcpostgresql-adapter`), got the following error:

```
superclass mismatch for class PostgreSQLColumn
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activerecord-postgres-hstore-0.7.5/lib/activerecord-postgres-hstore/acti
verecord.rb:70:in `ConnectionAdapters'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activerecord-postgres-hstore-0.7.5/lib/activerecord-postgres-hstore/acti
verecord.rb:69:in `ActiveRecord'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activerecord-postgres-hstore-0.7.5/lib/activerecord-postgres-hstore/acti
verecord.rb:2:in `(root)'
org/jruby/RubyKernel.java:1027:in `require'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `require'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:236:in `load_dep
endency'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activesupport-3.2.12/lib/active_support/dependencies.rb:251:in `require'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activerecord-postgres-hstore-0.7.5/lib/activerecord-postgres-hstore/rail
ties.rb:1:in `(root)'
org/jruby/RubyBasicObject.java:1709:in `instance_eval'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activerecord-postgres-hstore-0.7.5/lib/activerecord-postgres-hstore/rail
ties.rb:15:in `Hstore'
/home/ty/.rvm/gems/jruby-1.7.3@rails3/gems/activesupport-3.2.12/lib/active_support/lazy_load_hooks.rb:36:in `execut
e_hook'
org/jruby/RubyArray.java:1613:in `each'
...
```
