### PR TITLE
Use Travis to test against more rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,15 @@
 language: ruby
 rvm:
   - 1.9.3
+  - jruby-19mode
+  - rbx-19mode
+  - ruby-head
+  - jruby-head
+
+# jruby-head sometimes breaks stuff, but it's passing at the moment
+#matrix:
+#  allow_failures:
+#    - rvm: jruby-head
 
 branches:
   only:


### PR DESCRIPTION
Travis can test with Ruby implementations besides 1.9.3. This commit expands the matrix into also including JRuby in 1.9 mode, Rubinius in 1.9 mode, jruby-head, and ruby-head, all of which currently pass.

This doesn't catch the issue in #89 (see [this test build](https://travis-ci.org/willglynn/activerecord-postgres-hstore/builds/5819636)), suggesting some gaps in test coverage, but at least this way _something_ gets run under JRuby before each merge.
