### PR TITLE
Add Ruby 2.0.0 and Ruby 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.2
   - jruby-19mode
   - rbx-2
   - ruby-head


### PR DESCRIPTION
Would be great to know that Ruby 2.0.0 and Ruby 2.1.2 are supported.
